### PR TITLE
Fix bug that prevents resume after pause on devices

### DIFF
--- a/Classes/MainViewController.m
+++ b/Classes/MainViewController.m
@@ -327,6 +327,7 @@ static const NSInteger IFMChannelsMax = 3; // this should come from the feed!
 			}
 			case UIEventSubtypeRemoteControlStop:
 			{
+				self.lastStation = self.currentStation;
 				[self _stopStreamer];
 				break;
 			}

--- a/Classes/MainViewController.m
+++ b/Classes/MainViewController.m
@@ -337,7 +337,7 @@ static const NSInteger IFMChannelsMax = 3; // this should come from the feed!
 					self.lastStation = self.currentStation;
 					[self _stopStreamer];
 				}
-				else if (self.player.rate < 0.0001 && self.currentStation != nil)
+				else if (self.player.rate < 0.0001 && self.lastStation != nil)
 				{
 					[self _playChannel:[self.stations uiIndexForStation:self.lastStation]];
 				}


### PR DESCRIPTION
I noticed that resuming a paused stream doesn't work when I use my headphones.

Turns out that in when you click the pause/play button in the iOS UI, it emits Play and Pause events, but when you use the play/pause button on a device, `UIEventSubtypeRemoteControlTogglePlayPause` is triggered instead.

This commit fixes the bug that makes the pause button get stuck.