### PR TITLE
Fix crash when parsing the Now Playing info fails

### DIFF
--- a/Classes/MainViewController.m
+++ b/Classes/MainViewController.m
@@ -92,18 +92,20 @@ static const NSInteger IFMChannelsMax = 3; // this should come from the feed!
 			
 			[UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
 			
-			MPMediaItemArtwork *artwork = [[MPMediaItemArtwork alloc] initWithBoundsSize:self.currentStation.artwork.size requestHandler:^UIImage * _Nonnull(CGSize size) {
-				return self.currentStation.artwork;
-			}];
-			
-			NSDictionary *nowPlayingInfo = @{
-				MPMediaItemPropertyTitle: [NSString stringWithFormat:@"Intergalactic FM - %@", self.currentStation.name],
-				MPMediaItemPropertyArtist: nowPlaying,
-				MPNowPlayingInfoPropertyIsLiveStream: @(YES),
-				MPMediaItemPropertyArtwork: artwork
-			};
-
-			[[MPNowPlayingInfoCenter defaultCenter] setNowPlayingInfo:nowPlayingInfo];
+			if (nowPlaying) {
+				MPMediaItemArtwork *artwork = [[MPMediaItemArtwork alloc] initWithBoundsSize:self.currentStation.artwork.size requestHandler:^UIImage * _Nonnull(CGSize size) {
+					return self.currentStation.artwork;
+				}];
+				
+				NSDictionary *nowPlayingInfo = @{
+					MPMediaItemPropertyTitle: [NSString stringWithFormat:@"Intergalactic FM - %@", self.currentStation.name],
+					MPMediaItemPropertyArtist: nowPlaying,
+					MPNowPlayingInfoPropertyIsLiveStream: @(YES),
+					MPMediaItemPropertyArtwork: artwork
+				};
+				
+				[[MPNowPlayingInfoCenter defaultCenter] setNowPlayingInfo:nowPlayingInfo];
+			}
 		}];
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/superjohan/ifm/issues/21.

Can't have `nil` values in dictionaries. Should really add some nullability annotations everywhere.
