### PR TITLE
Populate Now Playing even when tracks service is down

### DIFF
--- a/Classes/MainViewController.m
+++ b/Classes/MainViewController.m
@@ -92,20 +92,18 @@ static const NSInteger IFMChannelsMax = 3; // this should come from the feed!
 			
 			[UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
 			
-			if (nowPlaying) {
-				MPMediaItemArtwork *artwork = [[MPMediaItemArtwork alloc] initWithBoundsSize:self.currentStation.artwork.size requestHandler:^UIImage * _Nonnull(CGSize size) {
-					return self.currentStation.artwork;
-				}];
-				
-				NSDictionary *nowPlayingInfo = @{
-					MPMediaItemPropertyTitle: [NSString stringWithFormat:@"Intergalactic FM - %@", self.currentStation.name],
-					MPMediaItemPropertyArtist: nowPlaying,
-					MPNowPlayingInfoPropertyIsLiveStream: @(YES),
-					MPMediaItemPropertyArtwork: artwork
-				};
-				
-				[[MPNowPlayingInfoCenter defaultCenter] setNowPlayingInfo:nowPlayingInfo];
-			}
+			MPMediaItemArtwork *artwork = [[MPMediaItemArtwork alloc] initWithBoundsSize:self.currentStation.artwork.size requestHandler:^UIImage * _Nonnull(CGSize size) {
+				return self.currentStation.artwork;
+			}];
+
+			NSDictionary *nowPlayingInfo = @{
+				MPMediaItemPropertyTitle: [NSString stringWithFormat:@"Intergalactic FM - %@", self.currentStation.name],
+				MPMediaItemPropertyArtist: nowPlaying ? nowPlaying : @"",
+				MPNowPlayingInfoPropertyIsLiveStream: @(YES),
+				MPMediaItemPropertyArtwork: artwork
+			};
+			
+			[[MPNowPlayingInfoCenter defaultCenter] setNowPlayingInfo:nowPlayingInfo];
 		}];
 	}
 }


### PR DESCRIPTION
This tweaks https://github.com/superjohan/ifm/pull/22 to still tell `MPNowPlayingInfoCenter` what station is currently playing, even if we don't have the current artist/song. This still allows Airplay and remote control when tracks.intergalactic.fm is down.

Looks like this:

![IMG_5572](https://github.com/superjohan/ifm/assets/233676/5b83c894-6dcb-41c9-b9a7-93ecb9237086)

Do you think tracks.intergalactic.fm will come back?