### PR TITLE
Extract the audio player to its own class

### DIFF
--- a/Classes/IFM_PlayerAppDelegate.m
+++ b/Classes/IFM_PlayerAppDelegate.m
@@ -8,12 +8,14 @@
 
 #import "IFM_PlayerAppDelegate.h"
 #import "MainViewController.h"
+#import "IFM-Swift.h"
 
 @implementation IFM_PlayerAppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
-{    
-	self.mainViewController = [[MainViewController alloc] initWithNibName:@"MainView" bundle:nil];
+{
+	IFMPlayer *player = [[IFMPlayer alloc] init];
+	self.mainViewController = [[MainViewController alloc] initWithNibName:@"MainView" bundle:nil player:player];
 	self.window.rootViewController = self.mainViewController;
     [self.window makeKeyAndVisible];
 	

--- a/Classes/MainViewController.h
+++ b/Classes/MainViewController.h
@@ -7,9 +7,11 @@
 //
 
 #import <QuartzCore/QuartzCore.h>
+#import "IFM-Swift.h"
 
 @interface MainViewController : UIViewController
 
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil player:(IFMPlayer *)player;
 - (void)resetAnimation;
 
 @end

--- a/Classes/MainViewController.m
+++ b/Classes/MainViewController.m
@@ -116,8 +116,8 @@ static const NSInteger IFMChannelsMax = 3; // this should come from the feed!
 		[[self.spinners objectAtIndexOrNil:channel] setHidden:!isWaiting];
 		[[self.playButtons objectAtIndexOrNil:channel] setEnabled:!isWaiting];
 		
-		[[self.stopButtons objectAtIndexOrNil:channel] setEnabled:isPlaying];
-		[[self.stopButtons objectAtIndexOrNil:channel] setHidden:!isPlaying];
+		[[self.stopButtons objectAtIndexOrNil:channel] setEnabled:isPlaying || isWaiting];
+		[[self.stopButtons objectAtIndexOrNil:channel] setHidden:!isPlaying && !isWaiting];
 	}
 	
 	if (![status.nowPlaying isEqualToString:self.nowPlayingLabel.text] )

--- a/Classes/MainViewController.m
+++ b/Classes/MainViewController.m
@@ -163,8 +163,6 @@ static const NSInteger IFMChannelsMax = 3; // this should come from the feed!
 	
 	[UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleLightContent;
 	
-	[[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
-
 	NSString *version = [NSBundle mainBundle].infoDictionary[@"CFBundleShortVersionString"];
 	NSString *introText = [NSString stringWithFormat:@"Intergalactic FM for iPhone version %@ — https://www.intergalactic.fm/ — Developed by Aero Deko and IFM dev corps", version];
 	
@@ -184,14 +182,6 @@ static const NSInteger IFMChannelsMax = 3; // this should come from the feed!
 	// If the player is already doing something, then update the UI state again with the status so the now playing label is correct
 	if (status.state == IFMPlayerStatePlaying || status.state == IFMPlayerStateWaiting) {
 		[self updateWithStatus:status];
-	}
-}
-
-- (void)remoteControlReceivedWithEvent:(UIEvent *)event
-{
-	if (event.type == UIEventTypeRemoteControl)
-	{
-		[self.player handleRemoteControlEventWithSubtype:event.subtype];
 	}
 }
 

--- a/IFM-Bridging-Header.h
+++ b/IFM-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/IFM-Bridging-Header.h
+++ b/IFM-Bridging-Header.h
@@ -2,3 +2,7 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
+#import "IFMStations.h"
+#import "IFMStationsUpdater.h"
+#import "IFMStation.h"
+#import "IFMNowPlaying.h"

--- a/IFM.xcodeproj/project.pbxproj
+++ b/IFM.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		90D0D58A115CA03F007C9F6F /* newch2playing.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = newch2playing.png; sourceTree = "<group>"; };
 		90D0D58B115CA03F007C9F6F /* newch3playing.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = newch3playing.png; sourceTree = "<group>"; };
 		90D6F5101287FCAE0060ED15 /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Default.png; sourceTree = "<group>"; };
+		90E025962B66440D00910575 /* IFM-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "IFM-Bridging-Header.h"; sourceTree = "<group>"; };
 		90EDC421112AA08000D1395C /* stop.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stop.png; sourceTree = "<group>"; };
 		90FB69401CF4D4B400706581 /* IFMStations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IFMStations.h; sourceTree = "<group>"; };
 		90FB69411CF4D4B400706581 /* IFMStations.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IFMStations.m; sourceTree = "<group>"; };
@@ -199,6 +200,7 @@
 		29B97315FDCFA39411CA2CEA /* Other Sources */ = {
 			isa = PBXGroup;
 			children = (
+				90E025962B66440D00910575 /* IFM-Bridging-Header.h */,
 				32CA4F630368D1EE00C91783 /* IFM_Player_Prefix.pch */,
 				29B97316FDCFA39411CA2CEA /* main.m */,
 			);
@@ -314,10 +316,11 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1500;
+				LastUpgradeCheck = 1520;
 				TargetAttributes = {
 					1D6058900D05DD3D006BFB54 = {
 						DevelopmentTeam = T583396HNX;
+						LastSwiftMigration = 1520;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -411,13 +414,16 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 5;
+				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = T583396HNX;
+				ENABLE_MODULE_VERIFIER = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -430,12 +436,18 @@
 					"\"$(SRCROOT)\"",
 				);
 				MARKETING_VERSION = 2.0.1;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "c99 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = com.aerodeko.ifm;
 				PRODUCT_NAME = IFM;
 				PROVISIONING_PROFILE = "cdd4c46e-1a97-4885-8b56-f4dd7f91c00f";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "IFM-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_PACKAGE_NAME = IFM;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -444,12 +456,15 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 5;
+				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = T583396HNX;
+				ENABLE_MODULE_VERIFIER = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = IFM_Player_Prefix.pch;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
@@ -460,11 +475,16 @@
 					"\"$(SRCROOT)\"",
 				);
 				MARKETING_VERSION = 2.0.1;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "c99 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = com.aerodeko.ifm;
 				PRODUCT_NAME = IFM;
 				PROVISIONING_PROFILE = "4c5262ed-c481-443f-93a8-6d5e9a2018cf";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "IFM-Bridging-Header.h";
+				SWIFT_PACKAGE_NAME = IFM;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -504,7 +524,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
+				PRODUCT_MODULE_NAME = IFM;
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "IFM-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 			};
 			name = "App Store";
 		};
@@ -513,12 +536,15 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 5;
+				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = T583396HNX;
+				ENABLE_MODULE_VERIFIER = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = IFM_Player_Prefix.pch;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
@@ -529,12 +555,17 @@
 					"\"$(SRCROOT)\"",
 				);
 				MARKETING_VERSION = 2.0.1;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "c99 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = com.aerodeko.ifm;
 				PRODUCT_NAME = IFM;
 				PROVISIONING_PROFILE = "4c5262ed-c481-443f-93a8-6d5e9a2018cf";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "4c5262ed-c481-443f-93a8-6d5e9a2018cf";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "IFM-Bridging-Header.h";
+				SWIFT_PACKAGE_NAME = IFM;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = "App Store";
@@ -576,8 +607,11 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_MODULE_NAME = IFM;
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "IFM-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -616,8 +650,12 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
+				PRODUCT_MODULE_NAME = IFM;
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OBJC_BRIDGING_HEADER = "IFM-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/IFM.xcodeproj/project.pbxproj
+++ b/IFM.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		90D0D58D115CA03F007C9F6F /* newch1playing.png in Resources */ = {isa = PBXBuildFile; fileRef = 90D0D589115CA03F007C9F6F /* newch1playing.png */; };
 		90D0D58E115CA03F007C9F6F /* newch2playing.png in Resources */ = {isa = PBXBuildFile; fileRef = 90D0D58A115CA03F007C9F6F /* newch2playing.png */; };
 		90D0D58F115CA03F007C9F6F /* newch3playing.png in Resources */ = {isa = PBXBuildFile; fileRef = 90D0D58B115CA03F007C9F6F /* newch3playing.png */; };
+		90E025982B66440D00910575 /* IFMPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E025972B66440D00910575 /* IFMPlayer.swift */; };
 		90EDC422112AA08000D1395C /* stop.png in Resources */ = {isa = PBXBuildFile; fileRef = 90EDC421112AA08000D1395C /* stop.png */; };
 		90FB69421CF4D4B400706581 /* IFMStations.m in Sources */ = {isa = PBXBuildFile; fileRef = 90FB69411CF4D4B400706581 /* IFMStations.m */; };
 		90FB69451CF4D5EE00706581 /* IFMStationsUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 90FB69441CF4D5EE00706581 /* IFMStationsUpdater.m */; };
@@ -113,6 +114,7 @@
 		90D0D58B115CA03F007C9F6F /* newch3playing.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = newch3playing.png; sourceTree = "<group>"; };
 		90D6F5101287FCAE0060ED15 /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Default.png; sourceTree = "<group>"; };
 		90E025962B66440D00910575 /* IFM-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "IFM-Bridging-Header.h"; sourceTree = "<group>"; };
+		90E025972B66440D00910575 /* IFMPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IFMPlayer.swift; sourceTree = "<group>"; };
 		90EDC421112AA08000D1395C /* stop.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stop.png; sourceTree = "<group>"; };
 		90FB69401CF4D4B400706581 /* IFMStations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IFMStations.h; sourceTree = "<group>"; };
 		90FB69411CF4D4B400706581 /* IFMStations.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IFMStations.m; sourceTree = "<group>"; };
@@ -275,6 +277,7 @@
 				90FB694A1CF4D98F00706581 /* IFMStation.m */,
 				904F5E091D00B5F6003A238D /* IFMNowPlaying.h */,
 				904F5E0A1D00B5F6003A238D /* IFMNowPlaying.m */,
+				90E025972B66440D00910575 /* IFMPlayer.swift */,
 			);
 			name = Stations;
 			sourceTree = "<group>";
@@ -399,6 +402,7 @@
 				1D3623260D0F684500981E51 /* IFM_PlayerAppDelegate.m in Sources */,
 				289233AE0DB2D0DB0083E9F9 /* MainViewController.m in Sources */,
 				90FB69481CF4D97000706581 /* IFMStationsResponseParser.m in Sources */,
+				90E025982B66440D00910575 /* IFMPlayer.swift in Sources */,
 				904F5E0B1D00B5F6003A238D /* IFMNowPlaying.m in Sources */,
 				90FB69451CF4D5EE00706581 /* IFMStationsUpdater.m in Sources */,
 				DB2AB66A15A9859C005A1E98 /* NSArray+IFMAdditions.m in Sources */,

--- a/IFM.xcodeproj/project.pbxproj
+++ b/IFM.xcodeproj/project.pbxproj
@@ -114,7 +114,7 @@
 		90D0D58B115CA03F007C9F6F /* newch3playing.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = newch3playing.png; sourceTree = "<group>"; };
 		90D6F5101287FCAE0060ED15 /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Default.png; sourceTree = "<group>"; };
 		90E025962B66440D00910575 /* IFM-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "IFM-Bridging-Header.h"; sourceTree = "<group>"; };
-		90E025972B66440D00910575 /* IFMPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IFMPlayer.swift; sourceTree = "<group>"; };
+		90E025972B66440D00910575 /* IFMPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IFMPlayer.swift; sourceTree = "<group>"; usesTabs = 0; };
 		90EDC421112AA08000D1395C /* stop.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stop.png; sourceTree = "<group>"; };
 		90FB69401CF4D4B400706581 /* IFMStations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IFMStations.h; sourceTree = "<group>"; };
 		90FB69411CF4D4B400706581 /* IFMStations.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IFMStations.m; sourceTree = "<group>"; };

--- a/IFMPlayer.swift
+++ b/IFMPlayer.swift
@@ -44,6 +44,7 @@ class IFMPlayer : NSObject {
         let player = AVPlayer(url: station.url)
         player.automaticallyWaitsToMinimizeStalling = true
         player.currentItem?.addObserver(self, forKeyPath: "status", options: [.old, .new], context: nil)
+        player.currentItem?.addObserver(self, forKeyPath: "error", options: [.old, .new], context: nil)
         player.addObserver(self, forKeyPath: "status", options: [.old, .new], context: nil)
         player.addObserver(self, forKeyPath: "rate", options: [.old, .new], context: nil)
         player.addObserver(self, forKeyPath: "reasonForWaitingToPlay", options: [.old, .new], context: nil)
@@ -58,6 +59,7 @@ class IFMPlayer : NSObject {
     
     @objc func stop() {
         self.player?.currentItem?.removeObserver(self, forKeyPath: "status")
+        self.player?.currentItem?.removeObserver(self, forKeyPath: "error")
         self.player?.removeObserver(self, forKeyPath: "status")
         self.player?.removeObserver(self, forKeyPath: "rate")
         self.player?.removeObserver(self, forKeyPath: "reasonForWaitingToPlay")
@@ -217,7 +219,7 @@ class IFMPlayer : NSObject {
                 }
             }
         } else if let playerItem = object as? AVPlayerItem {
-            if playerItem.status == .failed {
+            if playerItem.status == .failed || keyPath == "error" {
                 stop()
                 updateState(.error, channelIndex: -1)
             }

--- a/IFMPlayer.swift
+++ b/IFMPlayer.swift
@@ -1,0 +1,214 @@
+//
+//  IFMPlayer.swift
+//  IFM
+//
+//  Created by Johan Halin on 28.1.2024.
+//
+
+import Foundation
+import AVFoundation
+import MediaPlayer
+
+@objc
+class IFMPlayer : NSObject {
+	private(set) var state = State.Stopped
+	
+	private let stations = IFMStations()
+	private let nowPlayingUpdater = IFMNowPlaying()
+	private let listeners = NSMutableSet() // yeah, yeah, i'd actually use Combine instead
+	
+	private var player: AVPlayer? = nil
+	private var nowPlayingTimer: Timer? = nil
+	private var nowPlayingText: String? = nil
+	private var currentStation: IFMStation? = nil
+	private var lastStation: IFMStation? = nil
+	
+	override init() {
+		self.stations.update()
+			
+		try? AVAudioSession.sharedInstance().setCategory(.playback)
+		try? AVAudioSession.sharedInstance().setActive(true)
+	}
+	
+	// MARK: - Public
+	
+	@objc func play(channelIndex: Int) {
+		stop()
+
+		// [self _setPlayButtonsEnabled:YES]
+		
+		guard let station = self.stations.station(for: channelIndex) else { return }
+		let player = AVPlayer(url: station.url)
+		player.automaticallyWaitsToMinimizeStalling = true
+		player.currentItem?.addObserver(self, forKeyPath: "status", options: [.old, .new], context: nil)
+		player.addObserver(self, forKeyPath: "status", options: [.old, .new], context: nil)
+		player.addObserver(self, forKeyPath: "rate", options: [.old, .new], context: nil)
+		player.addObserver(self, forKeyPath: "reasonForWaitingToPlay", options: [.old, .new], context: nil)
+		player.play()
+		
+		self.player = player
+		self.currentStation = station
+		
+		updateNowPlaying()
+		// mark channel as waiting
+	}
+	
+	@objc func stop() {
+		self.player?.currentItem?.removeObserver(self, forKeyPath: "status")
+		self.player?.removeObserver(self, forKeyPath: "status")
+		self.player?.removeObserver(self, forKeyPath: "rate")
+		self.player?.removeObserver(self, forKeyPath: "reasonForWaitingToPlay")
+		self.player?.pause()
+		
+		self.player = nil
+		
+		self.nowPlayingTimer?.invalidate()
+		self.nowPlayingTimer = nil
+	}
+	
+	@objc func handleRemoteControlEvent(subtype: UIEvent.EventSubtype) {
+		switch subtype {
+		case .remoteControlPlay:
+			guard let lastStation = self.lastStation else { return }
+			play(channelIndex: self.stations.uiIndex(for: lastStation))
+
+		case .remoteControlPause:
+			self.lastStation = self.currentStation
+			stop()
+
+		case .remoteControlTogglePlayPause:
+			if (self.player?.rate ?? 0) > 0.0001 {
+				self.lastStation = self.currentStation
+				stop()
+			} else if (self.player?.rate ?? 0) < 0.0001, let lastStation = self.lastStation {
+				play(channelIndex: self.stations.uiIndex(for: lastStation))
+			}
+			
+		case .remoteControlNextTrack:
+			guard let currentStation = self.currentStation else { return }
+			var index = self.stations.uiIndex(for: currentStation)
+			
+			if index < (self.stations.numberOfStations - 1) {
+				index += 1
+			} else {
+				index = 0
+			}
+			
+			self.currentStation = self.stations.station(for: index)
+			
+			play(channelIndex: index)
+
+		case .remoteControlPreviousTrack:
+			guard let currentStation = self.currentStation else { return }
+			var index = self.stations.uiIndex(for: currentStation)
+			
+			if index == 0 {
+				index = self.stations.numberOfStations - 1
+			} else {
+				index -= 1
+			}
+			
+			self.currentStation = self.stations.station(for: index)
+			
+			play(channelIndex: index)
+
+		default:
+			break
+		}
+	}
+	
+	@objc func add(listener: IFMPlayerStatusListener) {
+		self.listeners.add(listener)
+	}
+	
+	@objc func remove(listener: IFMPlayerStatusListener) {
+		self.listeners.remove(listener)
+	}
+	
+	// MARK: - Private
+	
+	private func updateState(_ state: State, channelIndex: Int) {
+		self.state = state
+	}
+	
+	private func updateNowPlaying() {
+		guard let currentStation = self.currentStation, !self.nowPlayingUpdater.updating else {
+			return
+		}
+
+		self.nowPlayingUpdater.update(with: currentStation) { nowPlaying in
+			self.nowPlayingText = nowPlaying
+
+			// [self _updateNowPlayingLabel:nowPlaying] ->
+			// self.updateState(State.Playing, channelIndex: self.stations.uiIndex(for: currentStation)) // FIXME: state
+			
+			MPNowPlayingInfoCenter.default().nowPlayingInfo = [
+				MPMediaItemPropertyTitle: "Intergalactic FM - \(currentStation.name)",
+				MPMediaItemPropertyArtist: nowPlaying ?? "",
+				MPNowPlayingInfoPropertyIsLiveStream: true,
+				MPMediaItemPropertyArtwork: MPMediaItemArtwork(
+					boundsSize: currentStation.artwork.size,
+					requestHandler: { _ in currentStation.artwork }
+				),
+			]
+		}
+	}
+	
+	// MARK: - NSKeyValueObserving
+	
+	override func observeValue(
+		forKeyPath keyPath: String?,
+		of object: Any?,
+		change: [NSKeyValueChangeKey : Any]?,
+		context: UnsafeMutableRawPointer?
+	) {
+		if let player = object as? AVPlayer {
+			if keyPath == "rate" {
+				if player.rate < 0.00001 {
+					stop()
+				}
+			} else if keyPath == "reasonForWaitingToPlay" {
+				if player.reasonForWaitingToPlay != nil {
+					//[self _setChannelToWaiting:[self.stations uiIndexForStation:self.currentStation]]
+				} else {
+					self.nowPlayingTimer = Timer.scheduledTimer(
+						withTimeInterval: 15,
+						repeats: true,
+						block: { _ in self.updateNowPlaying() }
+					)
+					
+					updateNowPlaying()
+					
+					//[self _setChannelToPlaying:[self.stations uiIndexForStation:self.currentStation]]
+				}
+			} else if keyPath == "status" {
+				if player.status == .failed {
+					stop()
+					//[self _displayPlaylistError]
+				}
+			}
+		} else if let playerItem = object as? AVPlayerItem {
+			if playerItem.status == .failed {
+				stop()
+				//[self _displayPlaylistError]
+			}
+		} else {
+			// Not interested.
+			super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+		}
+	}
+
+	@objc enum State: Int {
+		case Stopped
+		case Waiting
+		case Playing
+	}
+}
+
+@objc class IFMPlayerStatus : NSObject {
+	
+}
+
+@objc protocol IFMPlayerStatusListener {
+	func update(status: IFMPlayerStatus)
+}

--- a/IFMPlayer.swift
+++ b/IFMPlayer.swift
@@ -214,6 +214,7 @@ class IFMPlayer : NSObject {
     case error
 }
 
+// TODO: wouldn't it be nice if this was a struct (see above)
 @objc class IFMPlayerStatus : NSObject {
     @objc let state: IFMPlayerState
     @objc let nowPlaying: String?
@@ -226,6 +227,7 @@ class IFMPlayer : NSObject {
     }
 }
 
+// TODO: damn it'd be nice to use Combine or somesuch instead of this junk (see above)
 @objc protocol IFMPlayerStatusListener {
     func update(status: IFMPlayerStatus)
 }

--- a/IFMPlayer.swift
+++ b/IFMPlayer.swift
@@ -99,6 +99,11 @@ class IFMPlayer : NSObject {
         guard let currentStation = self.currentStation, !self.nowPlayingUpdater.updating else { return }
         
         self.nowPlayingUpdater.update(with: currentStation) { nowPlaying in
+            // Was the player stopped while waiting for now playing info?
+            if self.player == nil {
+                return
+            }
+            
             self.nowPlayingText = nowPlaying
             
             self.updateState(self.status.state, channelIndex: self.stations.uiIndex(for: currentStation))

--- a/IFMPlayer.swift
+++ b/IFMPlayer.swift
@@ -11,221 +11,221 @@ import MediaPlayer
 
 @objc
 class IFMPlayer : NSObject {
-	@objc private(set) var status: IFMPlayerStatus
-
-	private let stations = IFMStations()
-	private let nowPlayingUpdater = IFMNowPlaying()
-	private let listeners = NSMutableSet() // yeah, yeah, i'd actually use Combine instead
-	
-	private var player: AVPlayer? = nil
-	private var nowPlayingTimer: Timer? = nil
-	private var nowPlayingText: String? = nil
-	private var currentStation: IFMStation? = nil
-	private var lastStation: IFMStation? = nil
-
-	override init() {
-		self.status = IFMPlayerStatus(state: .stopped, nowPlaying: nil, stationIndex: -1)
-		self.stations.update()
-		
-		try? AVAudioSession.sharedInstance().setCategory(.playback)
-		try? AVAudioSession.sharedInstance().setActive(true)
-	}
-	
-	// MARK: - Public
-	
-	@objc func play(channelIndex: Int) {
-		stop()
-
-		guard let station = self.stations.station(for: channelIndex) else { return }
-		let player = AVPlayer(url: station.url)
-		player.automaticallyWaitsToMinimizeStalling = true
-		player.currentItem?.addObserver(self, forKeyPath: "status", options: [.old, .new], context: nil)
-		player.addObserver(self, forKeyPath: "status", options: [.old, .new], context: nil)
-		player.addObserver(self, forKeyPath: "rate", options: [.old, .new], context: nil)
-		player.addObserver(self, forKeyPath: "reasonForWaitingToPlay", options: [.old, .new], context: nil)
-		player.play()
-		
-		self.player = player
-		self.currentStation = station
-		
-		updateNowPlaying()
-		updateState(.waiting, channelIndex: self.stations.uiIndex(for: station))
-	}
-	
-	@objc func stop() {
-		self.player?.currentItem?.removeObserver(self, forKeyPath: "status")
-		self.player?.removeObserver(self, forKeyPath: "status")
-		self.player?.removeObserver(self, forKeyPath: "rate")
-		self.player?.removeObserver(self, forKeyPath: "reasonForWaitingToPlay")
-		self.player?.pause()
-		
-		self.player = nil
-		
-		self.nowPlayingTimer?.invalidate()
-		self.nowPlayingTimer = nil
-		self.nowPlayingText = nil
-
-		updateState(.stopped, channelIndex: -1)
-	}
-	
-	@objc func handleRemoteControlEvent(subtype: UIEvent.EventSubtype) {
-		switch subtype {
-		case .remoteControlPlay:
-			guard let lastStation = self.lastStation else { return }
-			play(channelIndex: self.stations.uiIndex(for: lastStation))
-
-		case .remoteControlPause:
-			self.lastStation = self.currentStation
-			stop()
-
-		case .remoteControlTogglePlayPause:
-			if (self.player?.rate ?? 0) > 0.0001 {
-				self.lastStation = self.currentStation
-				stop()
-			} else if (self.player?.rate ?? 0) < 0.0001, let lastStation = self.lastStation {
-				play(channelIndex: self.stations.uiIndex(for: lastStation))
-			}
-			
-		case .remoteControlNextTrack:
-			guard let currentStation = self.currentStation else { return }
-			var index = self.stations.uiIndex(for: currentStation)
-			
-			if index < (self.stations.numberOfStations - 1) {
-				index += 1
-			} else {
-				index = 0
-			}
-			
-			self.currentStation = self.stations.station(for: index)
-			
-			play(channelIndex: index)
-
-		case .remoteControlPreviousTrack:
-			guard let currentStation = self.currentStation else { return }
-			var index = self.stations.uiIndex(for: currentStation)
-			
-			if index == 0 {
-				index = self.stations.numberOfStations - 1
-			} else {
-				index -= 1
-			}
-			
-			self.currentStation = self.stations.station(for: index)
-			
-			play(channelIndex: index)
-
-		default:
-			break
-		}
-	}
-	
-	@objc func addListener(_ listener: IFMPlayerStatusListener) {
-		self.listeners.add(listener)
-	}
-	
-	@objc func removeListener(_ listener: IFMPlayerStatusListener) {
-		self.listeners.remove(listener)
-	}
-	
-	// MARK: - Private
-	
-	// channelIndex is only used for .waiting and .playing, it can be anything for other states
-	private func updateState(_ state: IFMPlayerState, channelIndex: Int) {
-		self.status = IFMPlayerStatus(
-			state: state,
-			nowPlaying: self.nowPlayingText,
-			stationIndex: channelIndex
-		)
-		
-		for listener in self.listeners {
-			(listener as? IFMPlayerStatusListener)?.update(status: self.status)
-		}
-	}
-	
-	private func updateNowPlaying() {
-		guard let currentStation = self.currentStation, !self.nowPlayingUpdater.updating else { return }
-
-		self.nowPlayingUpdater.update(with: currentStation) { nowPlaying in
-			self.nowPlayingText = nowPlaying
-
-			self.updateState(self.status.state, channelIndex: self.stations.uiIndex(for: currentStation))
-			
-			MPNowPlayingInfoCenter.default().nowPlayingInfo = [
-				MPMediaItemPropertyTitle: "Intergalactic FM - \(currentStation.name)",
-				MPMediaItemPropertyArtist: nowPlaying ?? "",
-				MPNowPlayingInfoPropertyIsLiveStream: true,
-				MPMediaItemPropertyArtwork: MPMediaItemArtwork(
-					boundsSize: currentStation.artwork.size,
-					requestHandler: { _ in currentStation.artwork }
-				),
-			]
-		}
-	}
-	
-	// MARK: - NSKeyValueObserving
-	
-	override func observeValue(
-		forKeyPath keyPath: String?,
-		of object: Any?,
-		change: [NSKeyValueChangeKey : Any]?,
-		context: UnsafeMutableRawPointer?
-	) {
-		if let player = object as? AVPlayer {
-			if keyPath == "rate" {
-				if player.rate < 0.00001 {
-					stop()
-				}
-			} else if keyPath == "reasonForWaitingToPlay" {
-				if player.reasonForWaitingToPlay != nil, let station = self.currentStation {
-					updateState(.waiting, channelIndex: self.stations.uiIndex(for: station))
-				} else if let station = self.currentStation {
-					self.nowPlayingTimer = Timer.scheduledTimer(
-						withTimeInterval: 15,
-						repeats: true,
-						block: { _ in self.updateNowPlaying() }
-					)
-					
-					updateNowPlaying()
-					updateState(.playing, channelIndex: self.stations.uiIndex(for: station))
-				}
-			} else if keyPath == "status" {
-				if player.status == .failed {
-					stop()
-					updateState(.error, channelIndex: -1)
-				}
-			}
-		} else if let playerItem = object as? AVPlayerItem {
-			if playerItem.status == .failed {
-				stop()
-				updateState(.error, channelIndex: -1)
-			}
-		} else {
-			// Not interested.
-			super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
-		}
-	}
+    @objc private(set) var status: IFMPlayerStatus
+    
+    private let stations = IFMStations()
+    private let nowPlayingUpdater = IFMNowPlaying()
+    private let listeners = NSMutableSet() // yeah, yeah, i'd actually use Combine instead
+    
+    private var player: AVPlayer? = nil
+    private var nowPlayingTimer: Timer? = nil
+    private var nowPlayingText: String? = nil
+    private var currentStation: IFMStation? = nil
+    private var lastStation: IFMStation? = nil
+    
+    override init() {
+        self.status = IFMPlayerStatus(state: .stopped, nowPlaying: nil, stationIndex: -1)
+        self.stations.update()
+        
+        try? AVAudioSession.sharedInstance().setCategory(.playback)
+        try? AVAudioSession.sharedInstance().setActive(true)
+    }
+    
+    // MARK: - Public
+    
+    @objc func play(channelIndex: Int) {
+        stop()
+        
+        guard let station = self.stations.station(for: channelIndex) else { return }
+        let player = AVPlayer(url: station.url)
+        player.automaticallyWaitsToMinimizeStalling = true
+        player.currentItem?.addObserver(self, forKeyPath: "status", options: [.old, .new], context: nil)
+        player.addObserver(self, forKeyPath: "status", options: [.old, .new], context: nil)
+        player.addObserver(self, forKeyPath: "rate", options: [.old, .new], context: nil)
+        player.addObserver(self, forKeyPath: "reasonForWaitingToPlay", options: [.old, .new], context: nil)
+        player.play()
+        
+        self.player = player
+        self.currentStation = station
+        
+        updateNowPlaying()
+        updateState(.waiting, channelIndex: self.stations.uiIndex(for: station))
+    }
+    
+    @objc func stop() {
+        self.player?.currentItem?.removeObserver(self, forKeyPath: "status")
+        self.player?.removeObserver(self, forKeyPath: "status")
+        self.player?.removeObserver(self, forKeyPath: "rate")
+        self.player?.removeObserver(self, forKeyPath: "reasonForWaitingToPlay")
+        self.player?.pause()
+        
+        self.player = nil
+        
+        self.nowPlayingTimer?.invalidate()
+        self.nowPlayingTimer = nil
+        self.nowPlayingText = nil
+        
+        updateState(.stopped, channelIndex: -1)
+    }
+    
+    @objc func handleRemoteControlEvent(subtype: UIEvent.EventSubtype) {
+        switch subtype {
+        case .remoteControlPlay:
+            guard let lastStation = self.lastStation else { return }
+            play(channelIndex: self.stations.uiIndex(for: lastStation))
+            
+        case .remoteControlPause:
+            self.lastStation = self.currentStation
+            stop()
+            
+        case .remoteControlTogglePlayPause:
+            if (self.player?.rate ?? 0) > 0.0001 {
+                self.lastStation = self.currentStation
+                stop()
+            } else if (self.player?.rate ?? 0) < 0.0001, let lastStation = self.lastStation {
+                play(channelIndex: self.stations.uiIndex(for: lastStation))
+            }
+            
+        case .remoteControlNextTrack:
+            guard let currentStation = self.currentStation else { return }
+            var index = self.stations.uiIndex(for: currentStation)
+            
+            if index < (self.stations.numberOfStations - 1) {
+                index += 1
+            } else {
+                index = 0
+            }
+            
+            self.currentStation = self.stations.station(for: index)
+            
+            play(channelIndex: index)
+            
+        case .remoteControlPreviousTrack:
+            guard let currentStation = self.currentStation else { return }
+            var index = self.stations.uiIndex(for: currentStation)
+            
+            if index == 0 {
+                index = self.stations.numberOfStations - 1
+            } else {
+                index -= 1
+            }
+            
+            self.currentStation = self.stations.station(for: index)
+            
+            play(channelIndex: index)
+            
+        default:
+            break
+        }
+    }
+    
+    @objc func addListener(_ listener: IFMPlayerStatusListener) {
+        self.listeners.add(listener)
+    }
+    
+    @objc func removeListener(_ listener: IFMPlayerStatusListener) {
+        self.listeners.remove(listener)
+    }
+    
+    // MARK: - Private
+    
+    // channelIndex is only used for .waiting and .playing, it can be anything for other states
+    private func updateState(_ state: IFMPlayerState, channelIndex: Int) {
+        self.status = IFMPlayerStatus(
+            state: state,
+            nowPlaying: self.nowPlayingText,
+            stationIndex: channelIndex
+        )
+        
+        for listener in self.listeners {
+            (listener as? IFMPlayerStatusListener)?.update(status: self.status)
+        }
+    }
+    
+    private func updateNowPlaying() {
+        guard let currentStation = self.currentStation, !self.nowPlayingUpdater.updating else { return }
+        
+        self.nowPlayingUpdater.update(with: currentStation) { nowPlaying in
+            self.nowPlayingText = nowPlaying
+            
+            self.updateState(self.status.state, channelIndex: self.stations.uiIndex(for: currentStation))
+            
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = [
+                MPMediaItemPropertyTitle: "Intergalactic FM - \(currentStation.name)",
+                MPMediaItemPropertyArtist: nowPlaying ?? "",
+                MPNowPlayingInfoPropertyIsLiveStream: true,
+                MPMediaItemPropertyArtwork: MPMediaItemArtwork(
+                    boundsSize: currentStation.artwork.size,
+                    requestHandler: { _ in currentStation.artwork }
+                ),
+            ]
+        }
+    }
+    
+    // MARK: - NSKeyValueObserving
+    
+    override func observeValue(
+        forKeyPath keyPath: String?,
+        of object: Any?,
+        change: [NSKeyValueChangeKey : Any]?,
+        context: UnsafeMutableRawPointer?
+    ) {
+        if let player = object as? AVPlayer {
+            if keyPath == "rate" {
+                if player.rate < 0.00001 {
+                    stop()
+                }
+            } else if keyPath == "reasonForWaitingToPlay" {
+                if player.reasonForWaitingToPlay != nil, let station = self.currentStation {
+                    updateState(.waiting, channelIndex: self.stations.uiIndex(for: station))
+                } else if let station = self.currentStation {
+                    self.nowPlayingTimer = Timer.scheduledTimer(
+                        withTimeInterval: 15,
+                        repeats: true,
+                        block: { _ in self.updateNowPlaying() }
+                    )
+                    
+                    updateNowPlaying()
+                    updateState(.playing, channelIndex: self.stations.uiIndex(for: station))
+                }
+            } else if keyPath == "status" {
+                if player.status == .failed {
+                    stop()
+                    updateState(.error, channelIndex: -1)
+                }
+            }
+        } else if let playerItem = object as? AVPlayerItem {
+            if playerItem.status == .failed {
+                stop()
+                updateState(.error, channelIndex: -1)
+            }
+        } else {
+            // Not interested.
+            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+        }
+    }
 }
 
 // TODO: convert MainViewController to Swift so we can use associated types here
 @objc enum IFMPlayerState: Int {
-	case stopped
-	case waiting
-	case playing
-	case error
+    case stopped
+    case waiting
+    case playing
+    case error
 }
 
 @objc class IFMPlayerStatus : NSObject {
-	@objc let state: IFMPlayerState
-	@objc let nowPlaying: String?
-	@objc let stationIndex: Int
-	
-	init(state: IFMPlayerState, nowPlaying: String?, stationIndex: Int) {
-		self.state = state
-		self.nowPlaying = nowPlaying
-		self.stationIndex = stationIndex
-	}
+    @objc let state: IFMPlayerState
+    @objc let nowPlaying: String?
+    @objc let stationIndex: Int
+    
+    init(state: IFMPlayerState, nowPlaying: String?, stationIndex: Int) {
+        self.state = state
+        self.nowPlaying = nowPlaying
+        self.stationIndex = stationIndex
+    }
 }
 
 @objc protocol IFMPlayerStatusListener {
-	func update(status: IFMPlayerStatus)
+    func update(status: IFMPlayerStatus)
 }

--- a/IFMStation.h
+++ b/IFMStation.h
@@ -7,15 +7,16 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface IFMStation : NSObject
 
-@property (nonatomic, readonly) NSString *name;
-@property (nonatomic, readonly) NSURL *url;
-@property (nonatomic, readonly) NSURL *nowPlayingUrl;
-@property (nonatomic, readonly) UIImage *artwork;
+@property (nonatomic, readonly) NSString * _Nonnull name;
+@property (nonatomic, readonly) NSURL * _Nonnull url;
+@property (nonatomic, readonly) NSURL * _Nonnull nowPlayingUrl;
+@property (nonatomic, readonly) UIImage * _Nonnull artwork;
 
-- (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
-- (instancetype)init NS_UNAVAILABLE;
+- (instancetype _Nonnull )initWithDictionary:(NSDictionary *_Nonnull)dictionary NS_DESIGNATED_INITIALIZER;
+- (instancetype _Nonnull )init NS_UNAVAILABLE;
 
 @end


### PR DESCRIPTION
The player is now written in Swift. This is done in anticipation of CarPlay support, which will require exactly this if we want it to work properly. I also reworked the UI code quite extensively. It is now much simpler and straightforward. There may be some bugs I haven't run into yet, though.

`MainViewController` is so small now that it could also be rewritten in Swift, although I'd rather do that in a separate PR. It would make `IFMPlayer` a bit more ergonomic to use, since we could use associated types in enums and all that jazz.

Would either @alepar666 or @tijmenb be interested in reviewing/testing this?