### PR TITLE
Fix player state after interruption

### DIFF
--- a/IFMPlayer.swift
+++ b/IFMPlayer.swift
@@ -22,7 +22,6 @@ class IFMPlayer : NSObject {
     private var nowPlayingTimer: Timer? = nil
     private var nowPlayingText: String? = nil
     private var currentStation: IFMStation? = nil
-    private var lastStation: IFMStation? = nil
     
     var stateObservable: AnyPublisher<IFMPlayerState, Never> {
         self.statePublisher.eraseToAnyPublisher()
@@ -61,7 +60,6 @@ class IFMPlayer : NSObject {
         
         self.player = player
         self.currentStation = station
-        self.lastStation = station
 
         updateNowPlaying()
         updateState(.waiting(nowPlaying: self.nowPlayingText, stationIndex: self.stations.uiIndex(for: station)))
@@ -122,9 +120,9 @@ class IFMPlayer : NSObject {
         let commandCenter = MPRemoteCommandCenter.shared()
 
         commandCenter.playCommand.addTarget { _ in
-            guard let lastStation = self.lastStation else { return .noActionableNowPlayingItem }
+            guard let currentStation = self.currentStation else { return .noActionableNowPlayingItem }
 
-            self.play(channelIndex: self.stations.uiIndex(for: lastStation))
+            self.play(channelIndex: self.stations.uiIndex(for: currentStation))
             
             return .success
         }
@@ -138,8 +136,8 @@ class IFMPlayer : NSObject {
         commandCenter.togglePlayPauseCommand.addTarget { _ in
             if (self.player?.rate ?? 0) > 0.0001 {
                 self.stop()
-            } else if (self.player?.rate ?? 0) < 0.0001, let lastStation = self.lastStation {
-                self.play(channelIndex: self.stations.uiIndex(for: lastStation))
+            } else if (self.player?.rate ?? 0) < 0.0001, let currentStation = self.currentStation {
+                self.play(channelIndex: self.stations.uiIndex(for: currentStation))
             }
             
             return .success

--- a/IFMPlayer.swift
+++ b/IFMPlayer.swift
@@ -61,7 +61,8 @@ class IFMPlayer : NSObject {
         
         self.player = player
         self.currentStation = station
-        
+        self.lastStation = station
+
         updateNowPlaying()
         updateState(.waiting(nowPlaying: self.nowPlayingText, stationIndex: self.stations.uiIndex(for: station)))
     }
@@ -129,7 +130,6 @@ class IFMPlayer : NSObject {
         }
         
         commandCenter.pauseCommand.addTarget { _ in
-            self.lastStation = self.currentStation
             self.stop()
 
             return .success
@@ -137,7 +137,6 @@ class IFMPlayer : NSObject {
         
         commandCenter.togglePlayPauseCommand.addTarget { _ in
             if (self.player?.rate ?? 0) > 0.0001 {
-                self.lastStation = self.currentStation
                 self.stop()
             } else if (self.player?.rate ?? 0) < 0.0001, let lastStation = self.lastStation {
                 self.play(channelIndex: self.stations.uiIndex(for: lastStation))

--- a/IFMPlayer.swift
+++ b/IFMPlayer.swift
@@ -152,9 +152,7 @@ class IFMPlayer : NSObject {
             } else {
                 index = 0
             }
-            
-            self.currentStation = self.stations.station(for: index)
-            
+
             self.play(channelIndex: index)
             
             return .success
@@ -169,8 +167,6 @@ class IFMPlayer : NSObject {
             } else {
                 index -= 1
             }
-            
-            self.currentStation = self.stations.station(for: index)
             
             self.play(channelIndex: index)
             


### PR DESCRIPTION
When the audio session is interrupted, the player gets in a weird state where the play/pause button doesn't work anymore. That's because we don't have a lastStation yet, which I only saved (https://github.com/superjohan/ifm/pull/16) when we press pause for some reason.

First commit fixes the bug, but second commits simplifies the player logic to remove the `lastStation` stuff entirely because we don't actually need it.

Should fix #30 
