### PR TITLE
Speed up playback after play

### DIFF
--- a/IFMPlayer.swift
+++ b/IFMPlayer.swift
@@ -46,7 +46,11 @@ class IFMPlayer : NSObject {
         stop()
         
         guard let station = self.stations.station(for: channelIndex) else { return }
-        let player = AVPlayer(url: station.url)
+        
+        let playerItem = AVPlayerItem(url: station.url)
+        playerItem.preferredForwardBufferDuration = 1
+
+        let player = AVPlayer(playerItem: playerItem)
         player.automaticallyWaitsToMinimizeStalling = true
         player.currentItem?.addObserver(self, forKeyPath: "status", options: [.old, .new], context: nil)
         player.currentItem?.addObserver(self, forKeyPath: "error", options: [.old, .new], context: nil)


### PR DESCRIPTION
Currently we let AVPlayer decide how much of the stream to buffer. In practice it seems to take around 4-5 to hear something after pressing play or switching channels. This feels like a long time, and doesn't really match the experience in the browser, which starts playing instantly.

This sets the buffer size to 1 second. It's still a little buffer to deal with network issues, but it doesn't feel as sluggish.

Docs: https://developer.apple.com/documentation/avfoundation/avplayeritem/1643630-preferredforwardbufferduration